### PR TITLE
🪲 [Fix]: Remove preserve-credential on checkout

### DIFF
--- a/.github/workflows/Update-FontsData.yml
+++ b/.github/workflows/Update-FontsData.yml
@@ -21,3 +21,6 @@ jobs:
           ClientID: ${{ secrets.NERDFONTS_UPDATER_BOT_CLIENT_ID }}
           PrivateKey: ${{ secrets.NERDFONTS_UPDATER_BOT_PRIVATE_KEY }}
           Script: scripts/Update-FontsData.ps1
+          ShowInit: true
+          Debug: true
+          Verbose: true

--- a/.github/workflows/Update-FontsData.yml
+++ b/.github/workflows/Update-FontsData.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update-FontsData
         uses: PSModule/GitHub-Script@v1
@@ -21,6 +23,3 @@ jobs:
           ClientID: ${{ secrets.NERDFONTS_UPDATER_BOT_CLIENT_ID }}
           PrivateKey: ${{ secrets.NERDFONTS_UPDATER_BOT_PRIVATE_KEY }}
           Script: scripts/Update-FontsData.ps1
-          ShowInit: true
-          Debug: true
-          Verbose: true

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -1,4 +1,4 @@
-﻿Connect-GitHubApp -Organization PSModule
+﻿Connect-GitHubApp -Organization PSModule -Default
 
 git checkout main
 git pull

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -1,5 +1,23 @@
 ﻿Connect-GitHubApp -Organization PSModule -Default
 
+LogGroup 'gh auth' {
+    gh auth status
+}
+
+LogGroup "git config global" {
+    Get-GitHubGitConfig -Scope global
+}
+
+LogGroup "git config local" {
+    Get-GitHubGitConfig -Scope local
+}
+
+LogGroup "git config system" {
+    Get-GitHubGitConfig -Scope system
+}
+
+
+
 git checkout main
 git pull
 

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -5,15 +5,15 @@ LogGroup 'gh auth' {
 }
 
 LogGroup "git config global" {
-    Get-GitHubGitConfig -Scope global
+    Get-GitHubGitConfig -Scope global | Format-List
 }
 
 LogGroup "git config local" {
-    Get-GitHubGitConfig -Scope local
+    Get-GitHubGitConfig -Scope local | Format-List
 }
 
 LogGroup "git config system" {
-    Get-GitHubGitConfig -Scope system
+    Get-GitHubGitConfig -Scope system | Format-List
 }
 
 

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -1,23 +1,5 @@
 ﻿Connect-GitHubApp -Organization PSModule -Default
 
-LogGroup 'gh auth' {
-    gh auth status
-}
-
-LogGroup "git config global" {
-    Get-GitHubGitConfig -Scope global | Format-List
-}
-
-LogGroup "git config local" {
-    Get-GitHubGitConfig -Scope local | Format-List
-}
-
-LogGroup "git config system" {
-    Get-GitHubGitConfig -Scope system | Format-List
-}
-
-
-
 git checkout main
 git pull
 


### PR DESCRIPTION
## Description

This pull request includes changes to the `Update-FontsData` workflow and script to improve security and functionality. The most important changes include updating the GitHub Actions workflow to avoid persisting credentials and modifying the PowerShell script to use a default connection for the GitHub App.

Improvements to security and functionality:

* [`.github/workflows/Update-FontsData.yml`](diffhunk://#diff-5c6d6ac6744e613c22fe7a4b5bf6b9fbd4b3bf5548239191e4400a4b17440826R17-R18): Updated the `Checkout repository` step to avoid persisting credentials by setting `persist-credentials` to `false`.
* [`scripts/Update-FontsData.ps1`](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89L1-R1): Modified the `Connect-GitHubApp` command to use the `-Default` parameter for a default connection.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
