### PR TITLE
🩹 [Patch]: Light support for PS 5.1

### DIFF
--- a/src/classes/private/Scope.ps1
+++ b/src/classes/private/Scope.ps1
@@ -1,4 +1,0 @@
-﻿enum Scope {
-    CurrentUser
-    AllUsers
-}

--- a/src/functions/public/Install-NerdFont.ps1
+++ b/src/functions/public/Install-NerdFont.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Fonts'; RequiredVersion = '1.1.13' }
+﻿#Requires -Modules @{ ModuleName = 'Fonts'; RequiredVersion = '1.1.18' }
 
 function Install-NerdFont {
     <#

--- a/src/functions/public/Install-NerdFont.ps1
+++ b/src/functions/public/Install-NerdFont.ps1
@@ -51,9 +51,9 @@ function Install-NerdFont {
         )]
         [switch] $All,
 
-        # Specify the scope of where to install the font(s).
         [Parameter()]
-        [Scope] $Scope = 'CurrentUser',
+        [ValidateSet('CurrentUser', 'AllUsers')]
+        [string] $Scope = 'CurrentUser',
 
         # Force will overwrite existing fonts
         [Parameter()]

--- a/src/manifest.psd1
+++ b/src/manifest.psd1
@@ -1,0 +1,3 @@
+﻿@{
+    PowerShellVersion = '5.1'
+}


### PR DESCRIPTION
## Description

This pull request includes several changes to the PowerShell scripts and manifest file. The key changes involve updating module requirements, modifying parameter validation, and adding a manifest entry.

Updates to module requirements and parameter validation:

* [`src/functions/public/Install-NerdFont.ps1`](diffhunk://#diff-805a4a6beeb97eef72e8ff0b1bb90dee541f9da03df2803ab0a42416e5a8e794L1-R1): Updated the required version of the `Fonts` module from '1.1.13' to '1.1.18'.
* [`src/functions/public/Install-NerdFont.ps1`](diffhunk://#diff-805a4a6beeb97eef72e8ff0b1bb90dee541f9da03df2803ab0a42416e5a8e794L54-R56): Replaced the `Scope` enum with a `ValidateSet` parameter for `Scope` to specify valid values directly.

Removal of unused enum and addition of manifest entry:

* [`src/classes/private/Scope.ps1`](diffhunk://#diff-9f8b649c9594a7c7582dae3baf1841e8ffa82e1cbb7e1fae8b560b56f141e6f1L1-L4): Removed the `Scope` enum as it is no longer needed.
* [`src/manifest.psd1`](diffhunk://#diff-89820c99acb3b881e314c7e358eea621a8687cb4e0c687f541b9dcc9f30cc5dcR1-R3): Added a new entry to specify the required PowerShell version as '5.1'.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
