### PR TITLE
🩹 [Patch]: Refactor font data retrieval to use GitHub PowerShell

### DIFF
--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -17,7 +17,7 @@ $fontAssets = $release | Get-GitHubReleaseAsset | Where-Object { $_.Name -like '
 
 foreach ($fontArchive in $fontAssets) {
     $fonts += [PSCustomObject]@{
-        Name = $fontArchive.Name.Split('/')[-1].Split('.')[0]
+        Name = $fontArchive.Name.Split('.')[0]
         URL  = $fontArchive.Url
     }
 }

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -11,14 +11,14 @@ $branchName = "auto-font-update-$timeStamp"
 git checkout -b $branchName
 
 # 4. Retrieve the latest font data from Nerd Fonts.
-$release = Invoke-RestMethod 'https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest'
+$release = Get-GitHubRelease -Owner ryanoasis -Repository nerd-fonts
 $fonts = @()
-$fontArchives = $release.assets.browser_download_url | Where-Object { $_ -like '*.zip' }
+$fontAssets = $release | Get-GitHubReleaseAsset | Where-Object { $_.Name -like '*.zip' }
 
-foreach ($fontArchive in $fontArchives) {
-    $fonts += [ordered]@{
-        Name = $fontArchive.Split('/')[-1].Split('.')[0]
-        URL  = $fontArchive
+foreach ($fontArchive in $fontAssets) {
+    $fonts += [PSCustomObject]@{
+        Name = $fontArchive.Name.Split('/')[-1].Split('.')[0]
+        URL  = $fontArchive.Url
     }
 }
 


### PR DESCRIPTION
## Description

This pull request updates the `scripts/Update-FontsData.ps1` script to improve the retrieval of font data from the Nerd Fonts repository. The changes replace the use of `Invoke-RestMethod` with a more structured approach using custom PowerShell functions, enhancing readability and maintainability.

Enhancements to font data retrieval:

* Replaced low-level commands with GitHub PowerShell commands:
  * `Invoke-RestMethod` with `Get-GitHubRelease` to fetch the latest release data from the Nerd Fonts repository.
  * `browser_download_url` property under assets on a release, with `Get-GitHubReleaseAsset` to fetch the URL of the assets that are added to the release.
  * Updated the loop to use `[PSCustomObject]` instead of `[ordered]@` for better view and troubleshooting.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
