### PR TITLE
🩹 [Patch]: Use GitHub App again and some log and file formatting

### DIFF
--- a/.github/workflows/Update-FontsData.yml
+++ b/.github/workflows/Update-FontsData.yml
@@ -5,9 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   Update-FontsData:
@@ -23,4 +21,6 @@ jobs:
       - name: Update-FontsData
         uses: PSModule/GitHub-Script@v1
         with:
+          ClientID: ${{ secrets.NERDFONTS_UPDATER_BOT_CLIENT_ID }}
+          PrivateKey: ${{ secrets.NERDFONTS_UPDATER_BOT_PRIVATE_KEY }}
           Script: scripts/Update-FontsData.ps1

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -18,43 +18,53 @@
 
     try {
         Write-Verbose "Executing: $fullCommand"
-        & $cmd @arguments
+        $output = & $cmd @arguments
         if ($LASTEXITCODE -ne 0) {
             $errorMessage = "Command failed with exit code $LASTEXITCODE`: $fullCommand"
             Write-Error $errorMessage -ErrorId 'NativeCommandFailed' -Category OperationStopped -TargetObject $fullCommand
+        }
+        if ($output -is [array] -and $output.Count -gt 1) {
+            return $output -join "`n"
+        } else {
+            return $output
         }
     } catch {
         throw
     }
 }
 
-$currentBranch = (Run git rev-parse --abbrev-ref HEAD).Trim()
-$defaultBranch = (Run git remote show origin | Select-String 'HEAD branch:' | ForEach-Object { $_.ToString().Split(':')[1].Trim() })
-Write-Output "Current branch: $currentBranch"
-Write-Output "Default branch: $defaultBranch"
+Connect-GitHubApp -Organization 'PSModule' -Default
+$repo = Get-GitHubRepository -Owner 'PSModule' -Name 'NerdFonts'
 
-Run git fetch origin
-Run git checkout $defaultBranch
-Run git pull origin $defaultBranch
+LogGroup 'Checkout' {
+    $currentBranch = (Run git rev-parse --abbrev-ref HEAD).Trim()
+    $defaultBranch = $repo.DefaultBranch
 
-$timeStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-if ($currentBranch -eq $defaultBranch) {
-    # Running on main/default branch - create new branch
-    $targetBranch = "auto-update-font-$timeStamp"
-    Write-Output "Running on default branch. Creating new branch: $targetBranch"
-    Run git checkout -b $targetBranch
-} else {
-    # Running on another branch (e.g., workflow_dispatch) - use current branch
-    $targetBranch = $currentBranch
-    Write-Output "Running on feature branch. Using existing branch: $targetBranch"
-    Run git checkout $targetBranch
-    # Merge latest changes from default branch
-    Run git merge origin/$defaultBranch
+    Write-Output "Current branch: $currentBranch"
+    Write-Output "Default branch: $defaultBranch"
+    Run git fetch origin
+    Run git checkout $defaultBranch
+    Run git pull origin $defaultBranch
+
+    $timeStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    if ($currentBranch -eq $defaultBranch) {
+        # Running on main/default branch - create new branch
+        $targetBranch = "auto-update-$timeStamp"
+        Write-Output "Running on default branch. Creating new branch: $targetBranch"
+        Run git checkout -b $targetBranch
+    } else {
+        # Running on another branch (e.g., workflow_dispatch) - use current branch
+        $targetBranch = $currentBranch
+        Write-Output "Running on feature branch. Using existing branch: $targetBranch"
+        Run git checkout $targetBranch
+        # Merge latest changes from default branch
+        Run git merge origin/$defaultBranch
+    }
 }
 
-LogGroup 'Latest Fonts' {
-    $release = Get-GitHubRelease -Owner ryanoasis -Repository nerd-fonts
+LogGroup 'Getting latest fonts' {
     $fonts = @()
+    $release = Get-GitHubRelease -Owner ryanoasis -Repository nerd-fonts
     $fontAssets = $release | Get-GitHubReleaseAsset | Where-Object { $_.Name -like '*.zip' }
 
     foreach ($fontArchive in $fontAssets) {
@@ -65,38 +75,53 @@ LogGroup 'Latest Fonts' {
     }
 
     $fonts | Sort-Object Name | Format-Table -AutoSize | Out-String
+    $parentFolder = Split-Path -Path $PSScriptRoot -Parent
+    $filePath = Join-Path -Path $parentFolder -ChildPath 'src\FontsData.json'
+    $null = New-Item -Path $filePath -ItemType File -Force
+    $fonts | ConvertTo-Json | Set-Content -Path $filePath -Force
 }
-
-$parentFolder = Split-Path -Path $PSScriptRoot -Parent
-$filePath = Join-Path -Path $parentFolder -ChildPath 'src\FontsData.json'
-$null = New-Item -Path $filePath -ItemType File -Force
-$fonts | ConvertTo-Json | Set-Content -Path $filePath -Force
 
 $changes = Run git status --porcelain
 if ([string]::IsNullOrWhiteSpace($changes)) {
-    Write-Output 'No changes detected.'
+    Write-Output 'No updates available.'
+    Write-GitHubNotice 'No updates available.'
     return
 }
+LogGroup 'Get changes' {
+    Run git add .
+    Run git commit -m 'Update FontsData.json'
+    Write-Output 'Changes in this commit:'
+    $changes = Run git diff HEAD~1 HEAD -- src/FontsData.json
+    Write-Output $changes
+    Set-GitHubStepSummary @"
+## Changes available
 
-Run git add .
-Run git commit -m "Update-FontsData via script on $timeStamp"
-Write-Output 'Changes in this commit:'
-Run git diff HEAD~1 HEAD -- src/FontsData.json
+<details><summary>Details</summary>
+<p>
 
-# Push behavior depends on branch type
-if ($targetBranch -eq $currentBranch -and $currentBranch -ne $defaultBranch) {
-    # Push to existing branch
-    Run git push origin $targetBranch
-    Write-Output "Changes committed and pushed to existing branch: $targetBranch"
-} else {
-    # Push new branch and create PR
-    Run git push --set-upstream origin $targetBranch
+``````diff
+$changes
+``````
 
-    Run gh pr create `
-        --base $defaultBranch `
-        --head $targetBranch `
-        --title "Auto-Update: NerdFonts Data ($timeStamp)" `
-        --body 'This PR updates FontsData.json with the latest NerdFonts metadata.'
+</p>
+</details>
+"@
 
-    Write-Output "Changes detected and PR opened for branch: $targetBranch"
+}
+
+LogGroup 'Process changes' {
+    if ($targetBranch -eq $currentBranch -and $currentBranch -ne $defaultBranch) {
+        Run git push origin $targetBranch
+        Write-Output "Changes committed and pushed to existing branch: $targetBranch"
+    } else {
+        Run git push --set-upstream origin $targetBranch
+
+        Run gh pr create `
+            --base $defaultBranch `
+            --head $targetBranch `
+            --title "Auto-Update $timeStamp" `
+            --body 'This PR updates FontsData.json with the latest metadata.'
+
+        Write-Output "Changes detected and PR opened for branch: $targetBranch"
+    }
 }

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -33,6 +33,8 @@
     }
 }
 
+Install-PSResource -Repository PSGallery -TrustRepository -Name 'Json'
+
 Connect-GitHubApp -Organization 'PSModule' -Default
 $repo = Get-GitHubRepository -Owner 'PSModule' -Name 'NerdFonts'
 
@@ -78,7 +80,7 @@ LogGroup 'Getting latest fonts' {
     $parentFolder = Split-Path -Path $PSScriptRoot -Parent
     $filePath = Join-Path -Path $parentFolder -ChildPath 'src\FontsData.json'
     $null = New-Item -Path $filePath -ItemType File -Force
-    $fonts | ConvertTo-Json | Set-Content -Path $filePath -Force
+    $fonts | ConvertTo-Json | Format-Json -IndentationType Spaces -IndentationSize 4 | Set-Content -Path $filePath -Force
 }
 
 $changes = Run git status --porcelain

--- a/src/FontsData.json
+++ b/src/FontsData.json
@@ -1,290 +1,286 @@
 [
-  {
-    "Name": "0xProto",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
-  },
-  {
-    "Name": "Test",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Test.zip"
-  },
-  {
-    "Name": "3270",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
-  },
-  {
-    "Name": "AdwaitaMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
-  },
-  {
-    "Name": "Agave",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
-  },
-  {
-    "Name": "AnonymousPro",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
-  },
-  {
-    "Name": "Arimo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
-  },
-  {
-    "Name": "AtkinsonHyperlegibleMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
-  },
-  {
-    "Name": "AurulentSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
-  },
-  {
-    "Name": "BigBlueTerminal",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
-  },
-  {
-    "Name": "BitstreamVeraSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
-  },
-  {
-    "Name": "CascadiaCode",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
-  },
-  {
-    "Name": "CascadiaMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
-  },
-  {
-    "Name": "CodeNewRoman",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
-  },
-  {
-    "Name": "ComicShannsMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
-  },
-  {
-    "Name": "CommitMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
-  },
-  {
-    "Name": "Cousine",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
-  },
-  {
-    "Name": "D2Coding",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
-  },
-  {
-    "Name": "DaddyTimeMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
-  },
-  {
-    "Name": "DejaVuSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
-  },
-  {
-    "Name": "DepartureMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
-  },
-  {
-    "Name": "DroidSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
-  },
-  {
-    "Name": "EnvyCodeR",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
-  },
-  {
-    "Name": "FantasqueSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
-  },
-  {
-    "Name": "FiraCode",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
-  },
-  {
-    "Name": "FiraMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
-  },
-  {
-    "Name": "FontPatcher",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
-  },
-  {
-    "Name": "GeistMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
-  },
-  {
-    "Name": "Go-Mono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
-  },
-  {
-    "Name": "Gohu",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
-  },
-  {
-    "Name": "Hack",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
-  },
-  {
-    "Name": "Hasklig",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
-  },
-  {
-    "Name": "HeavyData",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
-  },
-  {
-    "Name": "Hermit",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
-  },
-  {
-    "Name": "iA-Writer",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
-  },
-  {
-    "Name": "IBMPlexMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
-  },
-  {
-    "Name": "Inconsolata",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
-  },
-  {
-    "Name": "InconsolataGo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
-  },
-  {
-    "Name": "InconsolataLGC",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
-  },
-  {
-    "Name": "IntelOneMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
-  },
-  {
-    "Name": "Iosevka",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
-  },
-  {
-    "Name": "IosevkaTerm",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
-  },
-  {
-    "Name": "IosevkaTermSlab",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
-  },
-  {
-    "Name": "JetBrainsMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
-  },
-  {
-    "Name": "Lekton",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
-  },
-  {
-    "Name": "LiberationMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
-  },
-  {
-    "Name": "Lilex",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
-  },
-  {
-    "Name": "MartianMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
-  },
-  {
-    "Name": "Meslo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
-  },
-  {
-    "Name": "Monaspace",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
-  },
-  {
-    "Name": "Monofur",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
-  },
-  {
-    "Name": "Monoid",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
-  },
-  {
-    "Name": "Mononoki",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
-  },
-  {
-    "Name": "MPlus",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
-  },
-  {
-    "Name": "NerdFontsSymbolsOnly",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
-  },
-  {
-    "Name": "Noto",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
-  },
-  {
-    "Name": "OpenDyslexic",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
-  },
-  {
-    "Name": "Overpass",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
-  },
-  {
-    "Name": "ProFont",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
-  },
-  {
-    "Name": "ProggyClean",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
-  },
-  {
-    "Name": "Recursive",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
-  },
-  {
-    "Name": "RobotoMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
-  },
-  {
-    "Name": "ShareTechMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
-  },
-  {
-    "Name": "SourceCodePro",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
-  },
-  {
-    "Name": "SpaceMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
-  },
-  {
-    "Name": "Terminus",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
-  },
-  {
-    "Name": "Tinos",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
-  },
-  {
-    "Name": "Ubuntu",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
-  },
-  {
-    "Name": "UbuntuMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
-  },
-  {
-    "Name": "UbuntuSans",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
-  },
-  {
-    "Name": "VictorMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
-  },
-  {
-    "Name": "ZedMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
-  }
+    {
+        "Name": "0xProto",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
+    },
+    {
+        "Name": "3270",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
+    },
+    {
+        "Name": "AdwaitaMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
+    },
+    {
+        "Name": "Agave",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
+    },
+    {
+        "Name": "AnonymousPro",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
+    },
+    {
+        "Name": "Arimo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
+    },
+    {
+        "Name": "AtkinsonHyperlegibleMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
+    },
+    {
+        "Name": "AurulentSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
+    },
+    {
+        "Name": "BigBlueTerminal",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
+    },
+    {
+        "Name": "BitstreamVeraSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
+    },
+    {
+        "Name": "CascadiaCode",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
+    },
+    {
+        "Name": "CascadiaMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
+    },
+    {
+        "Name": "CodeNewRoman",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
+    },
+    {
+        "Name": "ComicShannsMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
+    },
+    {
+        "Name": "CommitMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
+    },
+    {
+        "Name": "Cousine",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
+    },
+    {
+        "Name": "D2Coding",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
+    },
+    {
+        "Name": "DaddyTimeMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
+    },
+    {
+        "Name": "DejaVuSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
+    },
+    {
+        "Name": "DepartureMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
+    },
+    {
+        "Name": "DroidSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
+    },
+    {
+        "Name": "EnvyCodeR",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
+    },
+    {
+        "Name": "FantasqueSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
+    },
+    {
+        "Name": "FiraCode",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
+    },
+    {
+        "Name": "FiraMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
+    },
+    {
+        "Name": "FontPatcher",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
+    },
+    {
+        "Name": "GeistMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
+    },
+    {
+        "Name": "Go-Mono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
+    },
+    {
+        "Name": "Gohu",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
+    },
+    {
+        "Name": "Hack",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
+    },
+    {
+        "Name": "Hasklig",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
+    },
+    {
+        "Name": "HeavyData",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
+    },
+    {
+        "Name": "Hermit",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
+    },
+    {
+        "Name": "iA-Writer",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
+    },
+    {
+        "Name": "IBMPlexMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
+    },
+    {
+        "Name": "Inconsolata",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
+    },
+    {
+        "Name": "InconsolataGo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
+    },
+    {
+        "Name": "InconsolataLGC",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
+    },
+    {
+        "Name": "IntelOneMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
+    },
+    {
+        "Name": "Iosevka",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
+    },
+    {
+        "Name": "IosevkaTerm",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
+    },
+    {
+        "Name": "IosevkaTermSlab",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
+    },
+    {
+        "Name": "JetBrainsMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
+    },
+    {
+        "Name": "Lekton",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
+    },
+    {
+        "Name": "LiberationMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
+    },
+    {
+        "Name": "Lilex",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
+    },
+    {
+        "Name": "MartianMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
+    },
+    {
+        "Name": "Meslo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
+    },
+    {
+        "Name": "Monaspace",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
+    },
+    {
+        "Name": "Monofur",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
+    },
+    {
+        "Name": "Monoid",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
+    },
+    {
+        "Name": "Mononoki",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
+    },
+    {
+        "Name": "MPlus",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
+    },
+    {
+        "Name": "NerdFontsSymbolsOnly",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
+    },
+    {
+        "Name": "Noto",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
+    },
+    {
+        "Name": "OpenDyslexic",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
+    },
+    {
+        "Name": "Overpass",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
+    },
+    {
+        "Name": "ProFont",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
+    },
+    {
+        "Name": "ProggyClean",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
+    },
+    {
+        "Name": "Recursive",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
+    },
+    {
+        "Name": "RobotoMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
+    },
+    {
+        "Name": "ShareTechMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
+    },
+    {
+        "Name": "SourceCodePro",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
+    },
+    {
+        "Name": "SpaceMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
+    },
+    {
+        "Name": "Terminus",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
+    },
+    {
+        "Name": "Tinos",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
+    },
+    {
+        "Name": "Ubuntu",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
+    },
+    {
+        "Name": "UbuntuMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
+    },
+    {
+        "Name": "UbuntuSans",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
+    },
+    {
+        "Name": "VictorMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
+    },
+    {
+        "Name": "ZedMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
+    }
 ]

--- a/src/FontsData.json
+++ b/src/FontsData.json
@@ -4,6 +4,10 @@
     "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
   },
   {
+    "Name": "Test",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Test.zip"
+  },
+  {
     "Name": "3270",
     "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
   },

--- a/src/FontsData.json
+++ b/src/FontsData.json
@@ -1,286 +1,290 @@
 [
-  {
-    "Name": "0xProto",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
-  },
-  {
-    "Name": "3270",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
-  },
-  {
-    "Name": "AdwaitaMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
-  },
-  {
-    "Name": "Agave",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
-  },
-  {
-    "Name": "AnonymousPro",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
-  },
-  {
-    "Name": "Arimo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
-  },
-  {
-    "Name": "AtkinsonHyperlegibleMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
-  },
-  {
-    "Name": "AurulentSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
-  },
-  {
-    "Name": "BigBlueTerminal",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
-  },
-  {
-    "Name": "BitstreamVeraSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
-  },
-  {
-    "Name": "CascadiaCode",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
-  },
-  {
-    "Name": "CascadiaMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
-  },
-  {
-    "Name": "CodeNewRoman",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
-  },
-  {
-    "Name": "ComicShannsMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
-  },
-  {
-    "Name": "CommitMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
-  },
-  {
-    "Name": "Cousine",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
-  },
-  {
-    "Name": "D2Coding",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
-  },
-  {
-    "Name": "DaddyTimeMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
-  },
-  {
-    "Name": "DejaVuSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
-  },
-  {
-    "Name": "DepartureMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
-  },
-  {
-    "Name": "DroidSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
-  },
-  {
-    "Name": "EnvyCodeR",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
-  },
-  {
-    "Name": "FantasqueSansMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
-  },
-  {
-    "Name": "FiraCode",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
-  },
-  {
-    "Name": "FiraMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
-  },
-  {
-    "Name": "FontPatcher",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
-  },
-  {
-    "Name": "GeistMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
-  },
-  {
-    "Name": "Go-Mono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
-  },
-  {
-    "Name": "Gohu",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
-  },
-  {
-    "Name": "Hack",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
-  },
-  {
-    "Name": "Hasklig",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
-  },
-  {
-    "Name": "HeavyData",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
-  },
-  {
-    "Name": "Hermit",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
-  },
-  {
-    "Name": "iA-Writer",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
-  },
-  {
-    "Name": "IBMPlexMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
-  },
-  {
-    "Name": "Inconsolata",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
-  },
-  {
-    "Name": "InconsolataGo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
-  },
-  {
-    "Name": "InconsolataLGC",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
-  },
-  {
-    "Name": "IntelOneMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
-  },
-  {
-    "Name": "Iosevka",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
-  },
-  {
-    "Name": "IosevkaTerm",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
-  },
-  {
-    "Name": "IosevkaTermSlab",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
-  },
-  {
-    "Name": "JetBrainsMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
-  },
-  {
-    "Name": "Lekton",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
-  },
-  {
-    "Name": "LiberationMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
-  },
-  {
-    "Name": "Lilex",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
-  },
-  {
-    "Name": "MartianMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
-  },
-  {
-    "Name": "Meslo",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
-  },
-  {
-    "Name": "Monaspace",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
-  },
-  {
-    "Name": "Monofur",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
-  },
-  {
-    "Name": "Monoid",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
-  },
-  {
-    "Name": "Mononoki",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
-  },
-  {
-    "Name": "MPlus",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
-  },
-  {
-    "Name": "NerdFontsSymbolsOnly",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
-  },
-  {
-    "Name": "Noto",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
-  },
-  {
-    "Name": "OpenDyslexic",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
-  },
-  {
-    "Name": "Overpass",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
-  },
-  {
-    "Name": "ProFont",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
-  },
-  {
-    "Name": "ProggyClean",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
-  },
-  {
-    "Name": "Recursive",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
-  },
-  {
-    "Name": "RobotoMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
-  },
-  {
-    "Name": "ShareTechMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
-  },
-  {
-    "Name": "SourceCodePro",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
-  },
-  {
-    "Name": "SpaceMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
-  },
-  {
-    "Name": "Terminus",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
-  },
-  {
-    "Name": "Tinos",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
-  },
-  {
-    "Name": "Ubuntu",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
-  },
-  {
-    "Name": "UbuntuMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
-  },
-  {
-    "Name": "UbuntuSans",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
-  },
-  {
-    "Name": "VictorMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
-  },
-  {
-    "Name": "ZedMono",
-    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
-  }
+    {
+        "Name": "0xProto",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
+    },
+    {
+        "Name": "3270",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
+    },
+    {
+        "Name": "AdwaitaMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
+    },
+    {
+        "Name": "Test",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Test.zip"
+    },
+    {
+        "Name": "Agave",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
+    },
+    {
+        "Name": "AnonymousPro",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
+    },
+    {
+        "Name": "Arimo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
+    },
+    {
+        "Name": "AtkinsonHyperlegibleMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
+    },
+    {
+        "Name": "AurulentSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
+    },
+    {
+        "Name": "BigBlueTerminal",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
+    },
+    {
+        "Name": "BitstreamVeraSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
+    },
+    {
+        "Name": "CascadiaCode",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
+    },
+    {
+        "Name": "CascadiaMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
+    },
+    {
+        "Name": "CodeNewRoman",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
+    },
+    {
+        "Name": "ComicShannsMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
+    },
+    {
+        "Name": "CommitMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
+    },
+    {
+        "Name": "Cousine",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
+    },
+    {
+        "Name": "D2Coding",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
+    },
+    {
+        "Name": "DaddyTimeMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
+    },
+    {
+        "Name": "DejaVuSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
+    },
+    {
+        "Name": "DepartureMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
+    },
+    {
+        "Name": "DroidSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
+    },
+    {
+        "Name": "EnvyCodeR",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
+    },
+    {
+        "Name": "FantasqueSansMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
+    },
+    {
+        "Name": "FiraCode",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
+    },
+    {
+        "Name": "FiraMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
+    },
+    {
+        "Name": "FontPatcher",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
+    },
+    {
+        "Name": "GeistMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
+    },
+    {
+        "Name": "Go-Mono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
+    },
+    {
+        "Name": "Gohu",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
+    },
+    {
+        "Name": "Hack",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
+    },
+    {
+        "Name": "Hasklig",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
+    },
+    {
+        "Name": "HeavyData",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
+    },
+    {
+        "Name": "Hermit",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
+    },
+    {
+        "Name": "iA-Writer",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
+    },
+    {
+        "Name": "IBMPlexMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
+    },
+    {
+        "Name": "Inconsolata",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
+    },
+    {
+        "Name": "InconsolataGo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
+    },
+    {
+        "Name": "InconsolataLGC",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
+    },
+    {
+        "Name": "IntelOneMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
+    },
+    {
+        "Name": "Iosevka",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
+    },
+    {
+        "Name": "IosevkaTerm",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
+    },
+    {
+        "Name": "IosevkaTermSlab",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
+    },
+    {
+        "Name": "JetBrainsMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
+    },
+    {
+        "Name": "Lekton",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
+    },
+    {
+        "Name": "LiberationMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
+    },
+    {
+        "Name": "Lilex",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
+    },
+    {
+        "Name": "MartianMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
+    },
+    {
+        "Name": "Meslo",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
+    },
+    {
+        "Name": "Monaspace",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
+    },
+    {
+        "Name": "Monofur",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
+    },
+    {
+        "Name": "Monoid",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
+    },
+    {
+        "Name": "Mononoki",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
+    },
+    {
+        "Name": "MPlus",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
+    },
+    {
+        "Name": "NerdFontsSymbolsOnly",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
+    },
+    {
+        "Name": "Noto",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
+    },
+    {
+        "Name": "OpenDyslexic",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
+    },
+    {
+        "Name": "Overpass",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
+    },
+    {
+        "Name": "ProFont",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
+    },
+    {
+        "Name": "ProggyClean",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
+    },
+    {
+        "Name": "Recursive",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
+    },
+    {
+        "Name": "RobotoMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
+    },
+    {
+        "Name": "ShareTechMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
+    },
+    {
+        "Name": "SourceCodePro",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
+    },
+    {
+        "Name": "SpaceMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
+    },
+    {
+        "Name": "Terminus",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
+    },
+    {
+        "Name": "Tinos",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
+    },
+    {
+        "Name": "Ubuntu",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
+    },
+    {
+        "Name": "UbuntuMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
+    },
+    {
+        "Name": "UbuntuSans",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
+    },
+    {
+        "Name": "VictorMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
+    },
+    {
+        "Name": "ZedMono",
+        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
+    }
 ]

--- a/src/FontsData.json
+++ b/src/FontsData.json
@@ -1,290 +1,286 @@
 [
-    {
-        "Name": "0xProto",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
-    },
-    {
-        "Name": "3270",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
-    },
-    {
-        "Name": "AdwaitaMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
-    },
-    {
-        "Name": "Test",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Test.zip"
-    },
-    {
-        "Name": "Agave",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
-    },
-    {
-        "Name": "AnonymousPro",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
-    },
-    {
-        "Name": "Arimo",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
-    },
-    {
-        "Name": "AtkinsonHyperlegibleMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
-    },
-    {
-        "Name": "AurulentSansMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
-    },
-    {
-        "Name": "BigBlueTerminal",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
-    },
-    {
-        "Name": "BitstreamVeraSansMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
-    },
-    {
-        "Name": "CascadiaCode",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
-    },
-    {
-        "Name": "CascadiaMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
-    },
-    {
-        "Name": "CodeNewRoman",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
-    },
-    {
-        "Name": "ComicShannsMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
-    },
-    {
-        "Name": "CommitMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
-    },
-    {
-        "Name": "Cousine",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
-    },
-    {
-        "Name": "D2Coding",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
-    },
-    {
-        "Name": "DaddyTimeMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
-    },
-    {
-        "Name": "DejaVuSansMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
-    },
-    {
-        "Name": "DepartureMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
-    },
-    {
-        "Name": "DroidSansMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
-    },
-    {
-        "Name": "EnvyCodeR",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
-    },
-    {
-        "Name": "FantasqueSansMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
-    },
-    {
-        "Name": "FiraCode",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
-    },
-    {
-        "Name": "FiraMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
-    },
-    {
-        "Name": "FontPatcher",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
-    },
-    {
-        "Name": "GeistMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
-    },
-    {
-        "Name": "Go-Mono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
-    },
-    {
-        "Name": "Gohu",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
-    },
-    {
-        "Name": "Hack",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
-    },
-    {
-        "Name": "Hasklig",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
-    },
-    {
-        "Name": "HeavyData",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
-    },
-    {
-        "Name": "Hermit",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
-    },
-    {
-        "Name": "iA-Writer",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
-    },
-    {
-        "Name": "IBMPlexMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
-    },
-    {
-        "Name": "Inconsolata",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
-    },
-    {
-        "Name": "InconsolataGo",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
-    },
-    {
-        "Name": "InconsolataLGC",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
-    },
-    {
-        "Name": "IntelOneMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
-    },
-    {
-        "Name": "Iosevka",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
-    },
-    {
-        "Name": "IosevkaTerm",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
-    },
-    {
-        "Name": "IosevkaTermSlab",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
-    },
-    {
-        "Name": "JetBrainsMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
-    },
-    {
-        "Name": "Lekton",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
-    },
-    {
-        "Name": "LiberationMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
-    },
-    {
-        "Name": "Lilex",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
-    },
-    {
-        "Name": "MartianMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
-    },
-    {
-        "Name": "Meslo",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
-    },
-    {
-        "Name": "Monaspace",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
-    },
-    {
-        "Name": "Monofur",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
-    },
-    {
-        "Name": "Monoid",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
-    },
-    {
-        "Name": "Mononoki",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
-    },
-    {
-        "Name": "MPlus",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
-    },
-    {
-        "Name": "NerdFontsSymbolsOnly",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
-    },
-    {
-        "Name": "Noto",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
-    },
-    {
-        "Name": "OpenDyslexic",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
-    },
-    {
-        "Name": "Overpass",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
-    },
-    {
-        "Name": "ProFont",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
-    },
-    {
-        "Name": "ProggyClean",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
-    },
-    {
-        "Name": "Recursive",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
-    },
-    {
-        "Name": "RobotoMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
-    },
-    {
-        "Name": "ShareTechMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
-    },
-    {
-        "Name": "SourceCodePro",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
-    },
-    {
-        "Name": "SpaceMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
-    },
-    {
-        "Name": "Terminus",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
-    },
-    {
-        "Name": "Tinos",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
-    },
-    {
-        "Name": "Ubuntu",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
-    },
-    {
-        "Name": "UbuntuMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
-    },
-    {
-        "Name": "UbuntuSans",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
-    },
-    {
-        "Name": "VictorMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
-    },
-    {
-        "Name": "ZedMono",
-        "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
-    }
+  {
+    "Name": "0xProto",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/0xProto.zip"
+  },
+  {
+    "Name": "3270",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/3270.zip"
+  },
+  {
+    "Name": "AdwaitaMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AdwaitaMono.zip"
+  },
+  {
+    "Name": "Agave",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Agave.zip"
+  },
+  {
+    "Name": "AnonymousPro",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AnonymousPro.zip"
+  },
+  {
+    "Name": "Arimo",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Arimo.zip"
+  },
+  {
+    "Name": "AtkinsonHyperlegibleMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AtkinsonHyperlegibleMono.zip"
+  },
+  {
+    "Name": "AurulentSansMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/AurulentSansMono.zip"
+  },
+  {
+    "Name": "BigBlueTerminal",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BigBlueTerminal.zip"
+  },
+  {
+    "Name": "BitstreamVeraSansMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/BitstreamVeraSansMono.zip"
+  },
+  {
+    "Name": "CascadiaCode",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaCode.zip"
+  },
+  {
+    "Name": "CascadiaMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CascadiaMono.zip"
+  },
+  {
+    "Name": "CodeNewRoman",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CodeNewRoman.zip"
+  },
+  {
+    "Name": "ComicShannsMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ComicShannsMono.zip"
+  },
+  {
+    "Name": "CommitMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/CommitMono.zip"
+  },
+  {
+    "Name": "Cousine",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Cousine.zip"
+  },
+  {
+    "Name": "D2Coding",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/D2Coding.zip"
+  },
+  {
+    "Name": "DaddyTimeMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DaddyTimeMono.zip"
+  },
+  {
+    "Name": "DejaVuSansMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DejaVuSansMono.zip"
+  },
+  {
+    "Name": "DepartureMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DepartureMono.zip"
+  },
+  {
+    "Name": "DroidSansMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/DroidSansMono.zip"
+  },
+  {
+    "Name": "EnvyCodeR",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/EnvyCodeR.zip"
+  },
+  {
+    "Name": "FantasqueSansMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FantasqueSansMono.zip"
+  },
+  {
+    "Name": "FiraCode",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraCode.zip"
+  },
+  {
+    "Name": "FiraMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FiraMono.zip"
+  },
+  {
+    "Name": "FontPatcher",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/FontPatcher.zip"
+  },
+  {
+    "Name": "GeistMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/GeistMono.zip"
+  },
+  {
+    "Name": "Go-Mono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Go-Mono.zip"
+  },
+  {
+    "Name": "Gohu",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Gohu.zip"
+  },
+  {
+    "Name": "Hack",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip"
+  },
+  {
+    "Name": "Hasklig",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hasklig.zip"
+  },
+  {
+    "Name": "HeavyData",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/HeavyData.zip"
+  },
+  {
+    "Name": "Hermit",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hermit.zip"
+  },
+  {
+    "Name": "iA-Writer",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/iA-Writer.zip"
+  },
+  {
+    "Name": "IBMPlexMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IBMPlexMono.zip"
+  },
+  {
+    "Name": "Inconsolata",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Inconsolata.zip"
+  },
+  {
+    "Name": "InconsolataGo",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataGo.zip"
+  },
+  {
+    "Name": "InconsolataLGC",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/InconsolataLGC.zip"
+  },
+  {
+    "Name": "IntelOneMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IntelOneMono.zip"
+  },
+  {
+    "Name": "Iosevka",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Iosevka.zip"
+  },
+  {
+    "Name": "IosevkaTerm",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTerm.zip"
+  },
+  {
+    "Name": "IosevkaTermSlab",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/IosevkaTermSlab.zip"
+  },
+  {
+    "Name": "JetBrainsMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip"
+  },
+  {
+    "Name": "Lekton",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lekton.zip"
+  },
+  {
+    "Name": "LiberationMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/LiberationMono.zip"
+  },
+  {
+    "Name": "Lilex",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Lilex.zip"
+  },
+  {
+    "Name": "MartianMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MartianMono.zip"
+  },
+  {
+    "Name": "Meslo",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
+  },
+  {
+    "Name": "Monaspace",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monaspace.zip"
+  },
+  {
+    "Name": "Monofur",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monofur.zip"
+  },
+  {
+    "Name": "Monoid",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Monoid.zip"
+  },
+  {
+    "Name": "Mononoki",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Mononoki.zip"
+  },
+  {
+    "Name": "MPlus",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/MPlus.zip"
+  },
+  {
+    "Name": "NerdFontsSymbolsOnly",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/NerdFontsSymbolsOnly.zip"
+  },
+  {
+    "Name": "Noto",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Noto.zip"
+  },
+  {
+    "Name": "OpenDyslexic",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/OpenDyslexic.zip"
+  },
+  {
+    "Name": "Overpass",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Overpass.zip"
+  },
+  {
+    "Name": "ProFont",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProFont.zip"
+  },
+  {
+    "Name": "ProggyClean",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ProggyClean.zip"
+  },
+  {
+    "Name": "Recursive",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Recursive.zip"
+  },
+  {
+    "Name": "RobotoMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/RobotoMono.zip"
+  },
+  {
+    "Name": "ShareTechMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ShareTechMono.zip"
+  },
+  {
+    "Name": "SourceCodePro",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SourceCodePro.zip"
+  },
+  {
+    "Name": "SpaceMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/SpaceMono.zip"
+  },
+  {
+    "Name": "Terminus",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Terminus.zip"
+  },
+  {
+    "Name": "Tinos",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Tinos.zip"
+  },
+  {
+    "Name": "Ubuntu",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Ubuntu.zip"
+  },
+  {
+    "Name": "UbuntuMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuMono.zip"
+  },
+  {
+    "Name": "UbuntuSans",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/UbuntuSans.zip"
+  },
+  {
+    "Name": "VictorMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/VictorMono.zip"
+  },
+  {
+    "Name": "ZedMono",
+    "URL": "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/ZedMono.zip"
+  }
 ]


### PR DESCRIPTION
This pull request updates the workflow and script for automating the FontsData update process. Key changes include integration with GitHub App credentials, enhanced error handling, and formatting updates for better readability. The changes also streamline the process for detecting updates, committing changes, and creating pull requests.

### Workflow updates:

* [`.github/workflows/Update-FontsData.yml`](diffhunk://#diff-5c6d6ac6744e613c22fe7a4b5bf6b9fbd4b3bf5548239191e4400a4b17440826R24-R25): Added GitHub App credentials (`ClientID` and `PrivateKey`) for secure authentication during the update process. Removed permissions as these grant the GITHUB_TOKEN permissions, which is no longer used.

### Script enhancements:
* [`scripts/Update-FontsData.ps1`](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89L21-R54): Improved command execution to capture output and handle multiline results, returning formatted output when applicable.
* [`scripts/Update-FontsData.ps1`](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89L68-R129): Updated JSON formatting for `FontsData.json` to include indentation for better readability.
* [`scripts/Update-FontsData.ps1`](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89R65-R69): Enhanced logging and messaging, including clearer notices for no updates, summary of changes, and improved pull request titles and descriptions. [[1]](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89R65-R69) [[2]](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89L68-R129)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
