### PR TITLE
🩹 [Patch]: Add linter environment variables to PSModule.yml

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false


### PR DESCRIPTION
## Description

This pull request adds configuration to the `.github/PSModule.yml` file to disable several linter validations in the testing workflow. This helps control which linting checks are run during automated tests.

Testing configuration updates:

* Disabled various linter validations (`VALIDATE_BIOME_FORMAT`, `VALIDATE_BIOME_LINT`, `VALIDATE_GITHUB_ACTIONS_ZIZMOR`, `VALIDATE_JSCPD`, `VALIDATE_JSON_PRETTIER`, `VALIDATE_MARKDOWN_PRETTIER`, `VALIDATE_YAML_PRETTIER`) by setting their environment variables to `false` under the `Linter` section in `.github/PSModule.yml`.
