### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,6 +19,7 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
 Linter:
   env:
     VALIDATE_BIOME_FORMAT: false


### PR DESCRIPTION
## Description

This pull request makes a minor configuration update to the `.github/PSModule.yml` file, specifically disabling the Biome format validation in the linter environment.

* Set `VALIDATE_BIOME_FORMAT` to `false` in the linter environment to skip Biome format validation.