### PR TITLE
📖 [Docs]: Font check, update, and uninstall workflows now documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If the command returns results, the font is installed. If it returns nothing, th
 ### Update an installed NerdFont
 
 Individual font files do not embed a NerdFonts release version, so there is no direct way to check whether an installed
-NerdFont is outdated. To ensure you have the latest version, reinstall the font using the `-Force` parameter:
+NerdFont is outdated. To ensure you have the version bundled with the module, reinstall the font using the `-Force` parameter:
 
 ```powershell
 Install-NerdFont -Name 'FiraCode' -Force
@@ -87,7 +87,8 @@ If the font was originally installed for all users, update it with the matching 
 Install-NerdFont -Name 'FiraCode' -Force -Scope AllUsers
 ```
 
-This downloads and installs the font from the latest NerdFonts release, overwriting any existing version.
+This re-downloads and installs the font version bundled with your installed NerdFonts module, overwriting any existing
+files. To pick up newer font releases, update the NerdFonts module first (`Update-Module -Name NerdFonts`).
 
 ### Uninstall a NerdFont
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,53 @@ This requires the shell to run in an elevated context (sudo or run as administra
 Install-NerdFont -All -Scope AllUsers
 ```
 
+### Check if a NerdFont is installed
+
+The [Fonts](https://psmodule.io/Fonts) module is installed automatically as a dependency and provides the
+[`Get-Font`](https://psmodule.io/Fonts/Functions/Get-Font/) command for querying installed fonts on the system.
+
+To check if a specific NerdFont is installed for the current user:
+
+```powershell
+Get-Font -Name 'FiraCode*'
+```
+
+To check across all users on the system:
+
+```powershell
+Get-Font -Name 'FiraCode*' -Scope AllUsers
+```
+
+If the command returns results, the font is installed. If it returns nothing, the font is not installed in that scope.
+
+### Update an installed NerdFont
+
+Individual font files do not embed a NerdFonts release version, so there is no direct way to check whether an installed
+NerdFont is outdated. To ensure you have the latest version, reinstall the font using the `-Force` parameter:
+
+```powershell
+Install-NerdFont -Name 'FiraCode' -Force
+```
+
+This downloads and installs the font from the latest NerdFonts release, overwriting any existing version.
+
+### Uninstall a NerdFont
+
+To uninstall a NerdFont, use the [`Uninstall-Font`](https://psmodule.io/Fonts/Functions/Uninstall-Font/) command
+from the [Fonts](https://psmodule.io/Fonts) module (installed automatically as a dependency).
+
+To uninstall a NerdFont from the current user:
+
+```powershell
+Uninstall-Font -Name 'FiraCode*' # Tab completion works on name
+```
+
+To uninstall a NerdFont for all users (requires elevated privileges):
+
+```powershell
+Uninstall-Font -Name 'FiraCode*' -Scope AllUsers
+```
+
 ## Contributing
 
 Coder or not, you can contribute to the project! We welcome all contributions.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ NerdFont is outdated. To ensure you have the latest version, reinstall the font 
 Install-NerdFont -Name 'FiraCode' -Force
 ```
 
+If the font was originally installed for all users, update it with the matching scope (requires elevated privileges):
+
+```powershell
+Install-NerdFont -Name 'FiraCode' -Force -Scope AllUsers
+```
+
 This downloads and installs the font from the latest NerdFonts release, overwriting any existing version.
 
 ### Uninstall a NerdFont

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Install-NerdFont -Name 'FiraCode' -Scope AllUsers #Tab completion works on Scope
 To install all NerdFonts on the system you can use the following command.
 
 This will download and install all NerdFonts to the current user.
+
 ```powershell
 Install-NerdFont -All
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Install-NerdFont -Name 'FiraCode' -Force -Scope AllUsers
 ```
 
 This re-downloads and installs the font version bundled with your installed NerdFonts module, overwriting any existing
-files. To pick up newer font releases, update the NerdFonts module first (`Update-Module -Name NerdFonts`).
+files. To pick up newer font releases, update the NerdFonts module first (`Update-PSResource -Name NerdFonts` if you
+installed via PSResourceGet, or `Update-Module -Name NerdFonts` if you installed via PowerShellGet).
 
 ### Uninstall a NerdFont
 


### PR DESCRIPTION
The README now documents the three most common post-install workflows that were previously undiscoverable: checking whether a NerdFont is installed, updating to the latest version, and uninstalling a font. These workflows use the [Fonts](https://psmodule.io/Fonts) module that is already installed automatically as a dependency.

- Fixes #66

## New: Check if a NerdFont is installed

The README now includes examples showing how to use [`Get-Font`](https://psmodule.io/Fonts/Functions/Get-Font/) to query whether a specific NerdFont is installed, for both `CurrentUser` and `AllUsers` scopes.

## New: Update an installed NerdFont

A new section explains that font files do not embed a NerdFonts release version, so there is no direct "outdated" check. The documented approach is to reinstall with `Install-NerdFont -Name '<font>' -Force` to ensure the latest version.

## New: Uninstall a NerdFont

The README now shows how to use [`Uninstall-Font`](https://psmodule.io/Fonts/Functions/Uninstall-Font/) to remove NerdFonts, with examples for both user and system scopes. The section links to the Fonts module documentation and notes the dependency is installed automatically.

## Technical Details

- Only `README.md` was changed — no code changes.
- Three new subsections added under `## Usage`, following the established pattern of the existing install subsections.
- Each section references the Fonts module dependency and links to the relevant command documentation at [psmodule.io/Fonts](https://psmodule.io/Fonts).
- **Implementation plan progress**: All 4 tasks from issue #66 completed (check installed, update/reinstall, uninstall, dependency note).