### PR TITLE
⚙️ [Maintenance]: Lock Pester test dependency to the 6.x major version

### DIFF
--- a/tests/NerdFonts.Tests.ps1
+++ b/tests/NerdFonts.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSUseDeclaredVarsMoreThanAssignments', '',

--- a/tests/NerdFonts.Tests.ps1
+++ b/tests/NerdFonts.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.8.0'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.999.999'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSUseDeclaredVarsMoreThanAssignments', '',

--- a/tests/NerdFonts.Tests.ps1
+++ b/tests/NerdFonts.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.999.999'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSUseDeclaredVarsMoreThanAssignments', '',


### PR DESCRIPTION
This module's Pester tests now lock to the **6.x** major version instead of the exact `5.8.0` pin. An exact pin breaks whenever the runner resolves a different Pester (as happened once 5.8.0 was superseded); a major lock tracks every 6.x release while still blocking an unvetted new major.

## Changed: the exact 5.8.0 pin becomes a 6.x major lock

Each `*.Tests.ps1` file now requires:

```powershell
#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
```

Any Pester `6.x` satisfies it, so routine minor and patch updates no longer need a PR — only a new major does.

## Technical Details

- Updates the `#Requires -Modules` statement in each test file under `tests/` from `RequiredVersion = '5.8.0'` to `ModuleVersion = '6.0.0'; MaximumVersion = '6.*'`.
- Module-identity (`GUID`) pinning is intentionally omitted — a separate supply-chain control, not part of the lock-to-major risk appetite.
- The install side is locked to the same major in PSModule/Invoke-Pester#70. Part of the dependency-management epic PSModule/Process-PSModule#356.
