### PR TITLE
Fix invalid dependency version bounds

### DIFF
--- a/src/functions/public/Install-NerdFont.ps1
+++ b/src/functions/public/Install-NerdFont.ps1
@@ -1,5 +1,5 @@
-﻿#Requires -Modules @{ ModuleName = 'Fonts'; ModuleVersion = '1.1.0'; MaximumVersion = '1.*' }
-#Requires -Modules @{ ModuleName = 'Admin'; ModuleVersion = '1.1.0'; MaximumVersion = '1.*' }
+﻿#Requires -Modules @{ ModuleName = 'Fonts'; ModuleVersion = '1.1.0'; MaximumVersion = '1.999.999' }
+#Requires -Modules @{ ModuleName = 'Admin'; ModuleVersion = '1.1.0'; MaximumVersion = '1.999.999' }
 
 function Install-NerdFont {
     <#


### PR DESCRIPTION
## Summary

- replace wildcard `MaximumVersion` values with the valid `1.999.999` upper bound for `Admin` and `Fonts`
- allow PSResourceGet to package and publish the next NerdFonts release

## Validation

- `Invoke-Pester -Path .\tests\NerdFonts.Tests.ps1`
- verified the generated NuGet dependencies are `[1.1.0, 1.999.999]`